### PR TITLE
Add correct absolute import to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module olebedev/on
+module github.com/olebedev/on
 
 go 1.13
 


### PR DESCRIPTION
This enables installing with `go install github.com/olebedev/on`